### PR TITLE
Change Docker restart mode to unless-stopped

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
   # case.
   db:
     image: postgres:13-alpine
-    restart: on-failure
+    restart: unless-stopped
     volumes:
       - db:/var/lib/postgresql/data/
 
@@ -39,7 +39,7 @@ services:
         args:
           - BUILD_TYPE=release
     depends_on: [db]
-    restart: on-failure
+    restart: unless-stopped
 
     # All dirtsand services need this incantation so that the console doesn't hang the container.
     stdin_open: true


### PR DESCRIPTION
Previously this was `always` which caused containers to immediately start when the host computer booted, so it was changed to `on-failure` so that they'd restart if they crashed. There's still an edge case here where updating or restarting the docker daemon is considered failure and the containers still spin up on their own sometimes. I'm hoping that `unless-stopped` will be better about restarting on crashes but not in other circumstances.